### PR TITLE
Add a very simple image url scraper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,12 @@
             <version>3.6.0</version>
             <scope>compile</scope>
         </dependency>
+		<dependency>
+			<!-- jsoup HTML parser library @ https://jsoup.org/ -->
+			<groupId>org.jsoup</groupId>
+			<artifactId>jsoup</artifactId>
+			<version>1.13.1</version>
+		</dependency>
     </dependencies>
 
 	<build>

--- a/src/main/java/com/example/springbootstarterthymeleaf/database/AmazonImageURLScraper.java
+++ b/src/main/java/com/example/springbootstarterthymeleaf/database/AmazonImageURLScraper.java
@@ -1,0 +1,16 @@
+package com.example.springbootstarterthymeleaf.database;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+
+import java.io.IOException;
+
+public class AmazonImageURLScraper {
+    public static String getAmazonImageURL(String AmazonItemURL) throws IOException {
+        Document page = Jsoup.connect(AmazonItemURL).userAgent("Mozilla/5.0 (Windows NT 6.1; rv:80.0) Gecko/27132701 Firefox/78.7").data("name", "jsoup").get();
+        Element mainImageElement = page.selectFirst("#main-image-container"); // get the main image container
+        String URL = mainImageElement.selectFirst("img[src$=.jpg]").attr("src"); // find the fist jpg within the main image element
+        return URL;
+    }
+}

--- a/src/test/java/com/example/springbootstarterthymeleaf/AmazonImageURLScraperTest.java
+++ b/src/test/java/com/example/springbootstarterthymeleaf/AmazonImageURLScraperTest.java
@@ -1,0 +1,33 @@
+package com.example.springbootstarterthymeleaf;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.io.IOException;
+import java.util.Objects;
+
+import static com.example.springbootstarterthymeleaf.database.AmazonImageURLScraper.getAmazonImageURL;
+
+public class AmazonImageURLScraperTest {
+
+    @Test
+    void TestSimpleItem() throws IOException {
+        String AmazonURL = "https://www.amazon.com/Pepe-Frog-official-anatomically-correct/dp/B01MCT549R/";
+        String expectedImageURL = "https://images-na.ssl-images-amazon.com/images/I/61dnV42UYaL.__AC_SX300_SY300_QL70_ML2_.jpg";
+
+        String ImageURL = getAmazonImageURL(AmazonURL);
+
+        assert (expectedImageURL.equals(ImageURL));
+    }
+
+    @Test
+    void TestBookItem() throws IOException {
+        String AmazonURL = "https://www.amazon.com/Sonichu-0-C-W/dp/1699276854/";
+        String expectedImageURL = "https://images-na.ssl-images-amazon.com/images/I/51F9RP7npiL._SX218_BO1,204,203,200_QL40_ML2_.jpg";
+
+        String ImageURL = getAmazonImageURL(AmazonURL);
+
+        assert (expectedImageURL.equals(ImageURL));
+    }
+}
+

--- a/src/test/java/com/example/springbootstarterthymeleaf/AmazonImageURLScraperTest.java
+++ b/src/test/java/com/example/springbootstarterthymeleaf/AmazonImageURLScraperTest.java
@@ -1,0 +1,37 @@
+package com.example.springbootstarterthymeleaf;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.io.IOException;
+import java.util.Objects;
+
+import static com.example.springbootstarterthymeleaf.database.AmazonImageURLScraper.getAmazonImageURL;
+
+public class AmazonImageURLScraperTest {
+
+    @Test
+    void TestSimpleItem() throws IOException {
+        String AmazonURL = "https://www.amazon.com/Pepe-Frog-official-anatomically-correct/dp/B01MCT549R/";
+        String expectedImageURL = "https://images-na.ssl-images-amazon.com/images/I/61dnV42UYaL.__AC_SX300_SY300_QL70_ML2_.jpg";
+
+        String ImageURL = getAmazonImageURL(AmazonURL);
+
+        System.out.println(ImageURL);
+
+        assert (expectedImageURL.equals(ImageURL));
+    }
+
+    @Test
+    void TestBookItem() throws IOException {
+        String AmazonURL = "https://www.amazon.com/Sonichu-0-C-W/dp/1699276854/";
+        String expectedImageURL = "https://images-na.ssl-images-amazon.com/images/I/51F9RP7npiL._SX218_BO1,204,203,200_QL40_ML2_.jpg";
+
+        String ImageURL = getAmazonImageURL(AmazonURL);
+
+        System.out.println(ImageURL);
+
+        assert (expectedImageURL.equals(ImageURL));
+    }
+}
+


### PR DESCRIPTION
Since we are using amazon URLs in our database I think it would make sense to have the option to just automatically scrape Amazon for an image URL. The class I'm adding adds a very simple image scraper. I also added two tests to verify the correct URLs are scraped. 

We can use this to try to automatically pick up a URL and maybe give the user the option to request changing the item's image URL.

Run the tests if you would like to verify the code works.